### PR TITLE
`binding.NewInt().Get()` returns `(int, error)`

### DIFF
--- a/counter/main.go
+++ b/counter/main.go
@@ -14,7 +14,8 @@ func main() {
 
 	count := binding.NewInt()
 	button := widget.NewButton("Count", func() {
-		count.Set(count.Get()+1)
+		i, _ := count.Get()
+		count.Set(i+1)
 	})
 
 	w.SetContent(fyne.NewContainerWithLayout(layout.NewGridLayout(2),


### PR DESCRIPTION
Thus, it cannot be in-lined like this example showed.